### PR TITLE
 Strip Comments

### DIFF
--- a/docs/kyu_4.rst
+++ b/docs/kyu_4.rst
@@ -16,7 +16,7 @@ Subpackages
    kyu_4.range_extraction.module
    kyu_4.snail.module
    kyu_4.strings_mix.module
-   kyu_4.strip_comments
+   kyu_4.strip_comments.module
    kyu_4.sudoku_solution_validator
    kyu_4.sum_by_factors
    kyu_4.sum_of_intervals

--- a/docs/kyu_4.strip_comments.module.rst
+++ b/docs/kyu_4.strip_comments.module.rst
@@ -1,0 +1,11 @@
+kyu\_4.strip\_comments.module module
+====================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   kyu_4.strip_comments.readme
+   kyu_4.strip_comments

--- a/docs/kyu_4.strip_comments.readme.rst
+++ b/docs/kyu_4.strip_comments.readme.rst
@@ -1,0 +1,5 @@
+README
+======
+
+.. include:: ../kyu_4/strip_comments/README.md
+   :parser: myst_parser.sphinx_

--- a/kyu_4/strip_comments/solution.py
+++ b/kyu_4/strip_comments/solution.py
@@ -1,6 +1,9 @@
-#  Created by Egor Kostan.
-#  GitHub: https://github.com/ikostan
-#  LinkedIn: https://www.linkedin.com/in/egor-kostan/
+"""
+Solution for -> Strip Comments
+
+Created by Egor Kostan.
+GitHub: https://github.com/ikostan
+"""
 
 
 def solution(string: str, markers: list) -> str:
@@ -9,9 +12,9 @@ def solution(string: str, markers: list) -> str:
     of comment markers passed in. Any whitespace at the end
     of the line will be stripped out as well.
 
-    :param string:
-    :param markers:
-    :return:
+    :param string: str
+    :param markers: list
+    :return: str
     """
     strings: list = string.split('\n')
     for marker in markers:

--- a/kyu_4/strip_comments/test_solution.py
+++ b/kyu_4/strip_comments/test_solution.py
@@ -1,6 +1,9 @@
-#  Created by Egor Kostan.
-#  GitHub: https://github.com/ikostan
-#  LinkedIn: https://www.linkedin.com/in/egor-kostan/
+"""
+Test for -> Strip Comments
+
+Created by Egor Kostan.
+GitHub: https://github.com/ikostan
+"""
 
 # ALGORITHMS STRINGS
 
@@ -16,7 +19,8 @@ from kyu_4.strip_comments.solution import solution
 @allure.sub_suite("Unit Tests")
 @allure.feature("String")
 @allure.story("Strip Comments")
-@allure.tag('ALGORITHMS', 'STRINGS')
+@allure.tag('ALGORITHMS',
+            'STRINGS')
 @allure.link(url='https://www.codewars.com/kata/51c8e37cee245da6b40000bd/train/python',
              name='Source/Kata')
 class SolutionTestCase(unittest.TestCase):


### PR DESCRIPTION
Docs for:

# Strip Comments

Complete the solution so that it strips all text that follows any of a set of comment markers passed in. Any whitespace at the end of the line should also be stripped out.