### PR TITLE
Merge from master

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,7 @@
 [flake8]
+# Source:
+# https://flake8.pycqa.org/en/3.1.1/user/configuration.html#configuration
+# Errors to exclude:
 # W191 indentation contains tabs
 ignore = W191
 exclude =

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+# W191 indentation contains tabs
+ignore = W191
+exclude =
+    .git,
+    __pycache__,
+    .circleci,
+    .github,
+    .idea,
+    allure-report,
+    allure-results,
+    deprecated,
+    docs,
+    img,
+    venv
+max-complexity = 10
+max-line-length = 127

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -52,5 +52,5 @@ jobs:
           python -m flake8 . --count --select=E9,F63,F7,F82 --doctests --show-source --statistics
       - name: Complexity with flake8
         run: |
-          python -m flake8 . --count --max-complexity=10 --max-line-length=127 --benchmark --show-source --statistics
+          python -m flake8 . --count --benchmark --show-source --statistics
         # yamllint enable rule:line-length


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the `max-complexity` and `max-line-length` arguments from the flake8 invocation in the CI workflow.